### PR TITLE
Allow references to blocks/headers within the same files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ type MarkdownTree<'a> = Vec<Event<'a>>;
 
 lazy_static! {
     static ref OBSIDIAN_NOTE_LINK_RE: Regex =
-        Regex::new(r"^(?P<file>[^#|]+)(#(?P<section>.+?))??(\|(?P<label>.+?))??$").unwrap();
+        Regex::new(r"^(?P<file>[^#|]+)??(#(?P<section>.+?))??(\|(?P<label>.+?))??$").unwrap();
 }
 const PERCENTENCODE_CHARS: &AsciiSet = &CONTROLS.add(b' ').add(b'(').add(b')').add(b'%');
 const NOTE_RECURSION_LIMIT: usize = 10;
@@ -121,7 +121,8 @@ struct Context {
 /// ObsidianNoteReference represents the structure of a `[[note]]` or `![[embed]]` reference.
 struct ObsidianNoteReference<'a> {
     /// The file (note name or partial path) being referenced.
-    file: &'a str,
+    /// This will be None in the case that the reference is to a section within the same document
+    file: Option<&'a str>,
     /// If specific, a specific section/heading being referenced.
     section: Option<&'a str>,
     /// If specific, the custom label/text which was specified.
@@ -186,10 +187,7 @@ impl<'a> ObsidianNoteReference<'a> {
         let captures = OBSIDIAN_NOTE_LINK_RE
             .captures(&text)
             .expect("note link regex didn't match - bad input?");
-        let file = captures
-            .name("file")
-            .expect("Obsidian links should always reference a file")
-            .as_str();
+        let file = captures.name("file").map(|v| v.as_str());
         let label = captures.name("label").map(|v| v.as_str());
         let section = captures.name("section").map(|v| v.as_str());
 
@@ -210,9 +208,12 @@ impl<'a> fmt::Display for ObsidianNoteReference<'a> {
         let label = self
             .label
             .map(|v| v.to_string())
-            .unwrap_or_else(|| match self.section {
-                Some(section) => format!("{} > {}", self.file, section),
-                None => self.file.to_string(),
+            .unwrap_or_else(|| match (self.file, self.section) {
+                (Some(file), Some(section)) => format!("{} > {}", file, section),
+                (Some(file), None) => file.to_string(),
+                (None, Some(section)) => section.to_string(),
+
+                _ => panic!("Reference exists without file or section!"),
             })
             .to_string();
         write!(f, "{}", label)
@@ -458,12 +459,18 @@ impl<'a> Exporter<'a> {
     fn embed_file<'b>(&self, link_text: &'a str, context: &'a Context) -> Result<MarkdownTree<'a>> {
         let note_ref = ObsidianNoteReference::from_str(link_text);
 
-        let path = lookup_filename_in_vault(note_ref.file, &self.vault_contents.as_ref().unwrap());
+        let path = note_ref
+            .file
+            .map(|file| lookup_filename_in_vault(file, &self.vault_contents.as_ref().unwrap()))
+            .unwrap_or_else(|| Some(context.current_file()));
+
         if path.is_none() {
             // TODO: Extract into configurable function.
             eprintln!(
                 "Warning: Unable to find embedded note\n\tReference: '{}'\n\tSource: '{}'\n",
-                note_ref.file,
+                note_ref
+                    .file
+                    .unwrap_or_else(|| context.current_file().to_str().unwrap()),
                 context.current_file().display(),
             );
             return Ok(vec![]);
@@ -525,13 +532,18 @@ impl<'a> Exporter<'a> {
         reference: ObsidianNoteReference<'b>,
         context: &Context,
     ) -> MarkdownTree<'b> {
-        let target_file =
-            lookup_filename_in_vault(reference.file, &self.vault_contents.as_ref().unwrap());
+        let target_file = reference
+            .file
+            .map(|file| lookup_filename_in_vault(file, &self.vault_contents.as_ref().unwrap()))
+            .unwrap_or_else(|| Some(context.current_file()));
+
         if target_file.is_none() {
             // TODO: Extract into configurable function.
             eprintln!(
                 "Warning: Unable to find referenced note\n\tReference: '{}'\n\tSource: '{}'\n",
-                reference.file,
+                reference
+                    .file
+                    .unwrap_or_else(|| context.current_file().to_str().unwrap()),
                 context.current_file().display(),
             );
             return vec![

--- a/tests/testdata/expected/main-samples/section-ref-a.md
+++ b/tests/testdata/expected/main-samples/section-ref-a.md
@@ -1,0 +1,7 @@
+[This is a header](section-ref-a.md#this-is-a-header)
+
+[^dda637](section-ref-a.md#dda637)
+
+## This is a header
+
+This is a block ^dda637

--- a/tests/testdata/expected/main-samples/section-ref-b.md
+++ b/tests/testdata/expected/main-samples/section-ref-b.md
@@ -1,0 +1,2 @@
+[section-ref-a > This is a header](section-ref-a.md#this-is-a-header)
+[section-ref-a > ^dda637](section-ref-a.md#dda637)

--- a/tests/testdata/input/main-samples/section-ref-a.md
+++ b/tests/testdata/input/main-samples/section-ref-a.md
@@ -1,0 +1,7 @@
+[[#This is a header]]
+
+[[#^dda637]]
+
+## This is a header
+
+This is a block ^dda637

--- a/tests/testdata/input/main-samples/section-ref-b.md
+++ b/tests/testdata/input/main-samples/section-ref-b.md
@@ -1,0 +1,2 @@
+[[section-ref-a#This is a header]]
+[[section-ref-a#^dda637]]


### PR DESCRIPTION
`obsidian-export` currently assumes that the file component of a reference is always present. This is not the case for links to sections/headers within the same note (links in the form `[[#^id]]` or `[[#header-name]]`, see added test cases for an example) and causes the command to panic on the regex failing to match (and past that, when the file match is `unwrap`-ed).

This changes the regex to make the file component optional, and adds the required logic to make the outputted markdown links work.

The section links do not currently link _to_ anything, but markdown links are generated with a reasonable id and allow the program to run to completion.

I have run this against two of my vaults and it seems to work correctly (markdown served by [markserve](https://github.com/markserv/markserv)), but they are small and could be missing edge cases. Happy to fix any issues that arise.