### PR TITLE
Add support for postprocessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dtoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +317,7 @@ dependencies = [
  "pulldown-cmark-to-cmark",
  "rayon",
  "regex",
+ "serde_yaml",
  "slug",
  "snafu",
  "tempfile",
@@ -512,6 +525,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "serde"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "slug"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,3 +680,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ pulldown-cmark = "0.8.0"
 pulldown-cmark-to-cmark = "6.0.0"
 rayon = "1.5.0"
 regex = "1.4.3"
+serde_yaml = "0.8.17"
 slug = "0.1.4"
 snafu = "0.6.10"
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,93 @@
+use crate::Frontmatter;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+/// Context holds metadata about a note which is being parsed.
+///
+/// This is used internally to keep track of nesting and help with constructing proper references
+/// to other notes.
+///
+/// It is also passed to [postprocessors][crate::Postprocessor] to provide contextual information
+/// and allow modification of a note's frontmatter.
+pub struct Context {
+    file_tree: Vec<PathBuf>,
+
+    /// The path where this note will be written to when exported.
+    ///
+    /// Changing this path will result in the note being written to that new path instead, but
+    /// beware: links will not be updated automatically.  If this is changed by a
+    /// [postprocessor][crate::Postprocessor], it's up to that postprocessor to rewrite any
+    /// existing links to this new path.
+    pub destination: PathBuf,
+
+    /// The [Frontmatter] for this note. Frontmatter may be modified in-place (see
+    /// [serde_yaml::Mapping] for available methods) or replaced entirely.
+    ///
+    /// # Example
+    ///
+    /// Insert `foo: bar` into a note's frontmatter:
+    ///
+    /// ```
+    /// # use obsidian_export::Frontmatter;
+    /// # use obsidian_export::Context;
+    /// # use std::path::PathBuf;
+    /// use obsidian_export::serde_yaml::Value;
+    ///
+    /// # let mut context = Context::new(PathBuf::from("source"), PathBuf::from("destination"));
+    /// let key = Value::String("foo".to_string());
+    ///
+    /// context.frontmatter.insert(
+    ///     key.clone(),
+    ///     Value::String("bar".to_string()),
+    /// );
+    /// ```
+    pub frontmatter: Frontmatter,
+}
+
+impl Context {
+    /// Create a new `Context`
+    pub fn new(src: PathBuf, dest: PathBuf) -> Context {
+        Context {
+            file_tree: vec![src],
+            destination: dest,
+            frontmatter: Frontmatter::new(),
+        }
+    }
+
+    /// Create a new `Context` which inherits from a parent Context.
+    pub fn from_parent(context: &Context, child: &PathBuf) -> Context {
+        let mut context = context.clone();
+        context.file_tree.push(child.to_path_buf());
+        context
+    }
+
+    /// Return the path of the file currently being parsed.
+    pub fn current_file(&self) -> &PathBuf {
+        self.file_tree
+            .last()
+            .expect("Context not initialized properly, file_tree is empty")
+    }
+
+    /// Return the path of the root file.
+    ///
+    /// Typically this will yield the same element as `current_file`, but when a note is embedded
+    /// within another note, this will return the outer-most note.
+    pub fn root_file(&self) -> &PathBuf {
+        self.file_tree
+            .first()
+            .expect("Context not initialized properly, file_tree is empty")
+    }
+
+    /// Return the note depth (nesting level) for this context.
+    pub fn note_depth(&self) -> usize {
+        self.file_tree.len()
+    }
+
+    /// Return the list of files associated with this context.
+    ///
+    /// The first element corresponds to the root file, the final element corresponds to the file
+    /// which is currently being processed (see also `current_file`).
+    pub fn file_tree(&self) -> Vec<PathBuf> {
+        self.file_tree.clone()
+    }
+}

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,0 +1,92 @@
+use serde_yaml::Result;
+
+/// YAML front matter from an Obsidian note.
+///
+/// This is essentially an alias of [serde_yaml::Mapping] so all the methods available on that type
+/// are available with `Frontmatter` as well.
+///
+/// # Examples
+///
+/// ```
+/// # use obsidian_export::Frontmatter;
+/// use serde_yaml::Value;
+///
+/// let mut frontmatter = Frontmatter::new();
+/// let key = Value::String("foo".to_string());
+///
+/// frontmatter.insert(
+///     key.clone(),
+///     Value::String("bar".to_string()),
+/// );
+///
+/// assert_eq!(
+///     frontmatter.get(&key),
+///     Some(&Value::String("bar".to_string())),
+/// )
+/// ```
+pub type Frontmatter = serde_yaml::Mapping;
+
+pub fn frontmatter_from_str(mut s: &str) -> Result<Frontmatter> {
+    if s.is_empty() {
+        s = "{}";
+    }
+    let frontmatter: Frontmatter = serde_yaml::from_str(s)?;
+    Ok(frontmatter)
+}
+
+pub fn frontmatter_to_str(frontmatter: Frontmatter) -> Result<String> {
+    if frontmatter.is_empty() {
+        return Ok("---\n---\n".to_string());
+    }
+
+    let mut buffer = String::new();
+    buffer.push_str(&serde_yaml::to_string(&frontmatter)?);
+    buffer.push_str("---\n");
+    Ok(buffer)
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Available strategies for the inclusion of frontmatter in notes.
+pub enum FrontmatterStrategy {
+    /// Copy frontmatter when a note has frontmatter defined.
+    Auto,
+    /// Always add frontmatter header, including empty frontmatter when none was originally
+    /// specified.
+    Always,
+    /// Never add any frontmatter to notes.
+    Never,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_yaml::Value;
+
+    #[test]
+    fn empty_string_should_yield_empty_frontmatter() {
+        assert_eq!(frontmatter_from_str("").unwrap(), Frontmatter::new())
+    }
+
+    #[test]
+    fn empty_frontmatter_to_str() {
+        let frontmatter = Frontmatter::new();
+        assert_eq!(
+            frontmatter_to_str(frontmatter).unwrap(),
+            format!("---\n---\n")
+        )
+    }
+
+    #[test]
+    fn nonempty_frontmatter_to_str() {
+        let mut frontmatter = Frontmatter::new();
+        frontmatter.insert(
+            Value::String("foo".to_string()),
+            Value::String("bar".to_string()),
+        );
+        assert_eq!(
+            frontmatter_to_str(frontmatter).unwrap(),
+            format!("---\nfoo: bar\n---\n")
+        )
+    }
+}

--- a/src/references.rs
+++ b/src/references.rs
@@ -1,0 +1,204 @@
+use regex::Regex;
+use std::fmt;
+
+lazy_static! {
+    static ref OBSIDIAN_NOTE_LINK_RE: Regex =
+        Regex::new(r"^(?P<file>[^#|]+)??(#(?P<section>.+?))??(\|(?P<label>.+?))??$").unwrap();
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// ObsidianNoteReference represents the structure of a `[[note]]` or `![[embed]]` reference.
+pub struct ObsidianNoteReference<'a> {
+    /// The file (note name or partial path) being referenced.
+    /// This will be None in the case that the reference is to a section within the same document
+    pub file: Option<&'a str>,
+    /// If specific, a specific section/heading being referenced.
+    pub section: Option<&'a str>,
+    /// If specific, the custom label/text which was specified.
+    pub label: Option<&'a str>,
+}
+
+#[derive(PartialEq)]
+/// RefParserState enumerates all the possible parsing states [RefParser] may enter.
+pub enum RefParserState {
+    NoState,
+    ExpectSecondOpenBracket,
+    ExpectRefText,
+    ExpectRefTextOrCloseBracket,
+    ExpectFinalCloseBracket,
+    Resetting,
+}
+
+/// RefType indicates whether a note reference is a link (`[[note]]`) or embed (`![[embed]]`).
+pub enum RefType {
+    Link,
+    Embed,
+}
+
+/// RefParser holds state which is used to parse Obsidian WikiLinks (`[[note]]`, `![[embed]]`).
+pub struct RefParser {
+    pub state: RefParserState,
+    pub ref_type: Option<RefType>,
+    // References sometimes come in through multiple events. One example of this is when notes
+    // start with an underscore (_), presumably because this is also the literal which starts
+    // italic and bold text.
+    //
+    // ref_text concatenates the values from these partial events so that there's a fully-formed
+    // string to work with by the time the final `]]` is encountered.
+    pub ref_text: String,
+}
+
+impl RefParser {
+    pub fn new() -> RefParser {
+        RefParser {
+            state: RefParserState::NoState,
+            ref_type: None,
+            ref_text: String::new(),
+        }
+    }
+
+    pub fn transition(&mut self, new_state: RefParserState) {
+        self.state = new_state;
+    }
+
+    pub fn reset(&mut self) {
+        self.state = RefParserState::NoState;
+        self.ref_type = None;
+        self.ref_text.clear();
+    }
+}
+
+impl<'a> ObsidianNoteReference<'a> {
+    pub fn from_str(text: &str) -> ObsidianNoteReference {
+        let captures = OBSIDIAN_NOTE_LINK_RE
+            .captures(&text)
+            .expect("note link regex didn't match - bad input?");
+        let file = captures.name("file").map(|v| v.as_str());
+        let label = captures.name("label").map(|v| v.as_str());
+        let section = captures.name("section").map(|v| v.as_str());
+
+        ObsidianNoteReference {
+            file,
+            label,
+            section,
+        }
+    }
+
+    pub fn display(&self) -> String {
+        format!("{}", self)
+    }
+}
+
+impl<'a> fmt::Display for ObsidianNoteReference<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label =
+            self.label
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| match (self.file, self.section) {
+                    (Some(file), Some(section)) => format!("{} > {}", file, section),
+                    (Some(file), None) => file.to_string(),
+                    (None, Some(section)) => section.to_string(),
+
+                    _ => panic!("Reference exists without file or section!"),
+                });
+        write!(f, "{}", label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_note_refs_from_strings() {
+        assert_eq!(
+            ObsidianNoteReference::from_str("Just a note"),
+            ObsidianNoteReference {
+                file: Some("Just a note"),
+                label: None,
+                section: None,
+            }
+        );
+        assert_eq!(
+            ObsidianNoteReference::from_str("A note?"),
+            ObsidianNoteReference {
+                file: Some("A note?"),
+                label: None,
+                section: None,
+            }
+        );
+        assert_eq!(
+            ObsidianNoteReference::from_str("Note#with heading"),
+            ObsidianNoteReference {
+                file: Some("Note"),
+                label: None,
+                section: Some("with heading"),
+            }
+        );
+        assert_eq!(
+            ObsidianNoteReference::from_str("Note#Heading|Label"),
+            ObsidianNoteReference {
+                file: Some("Note"),
+                label: Some("Label"),
+                section: Some("Heading"),
+            }
+        );
+        assert_eq!(
+            ObsidianNoteReference::from_str("#Heading|Label"),
+            ObsidianNoteReference {
+                file: None,
+                label: Some("Label"),
+                section: Some("Heading"),
+            }
+        );
+    }
+
+    #[test]
+    fn test_display_of_note_refs() {
+        assert_eq!(
+            "Note",
+            ObsidianNoteReference {
+                file: Some("Note"),
+                label: None,
+                section: None,
+            }
+            .display()
+        );
+        assert_eq!(
+            "Note > Heading",
+            ObsidianNoteReference {
+                file: Some("Note"),
+                label: None,
+                section: Some("Heading"),
+            }
+            .display()
+        );
+        assert_eq!(
+            "Heading",
+            ObsidianNoteReference {
+                file: None,
+                label: None,
+                section: Some("Heading"),
+            }
+            .display()
+        );
+        assert_eq!(
+            "Label",
+            ObsidianNoteReference {
+                file: Some("Note"),
+                label: Some("Label"),
+                section: Some("Heading"),
+            }
+            .display()
+        );
+        assert_eq!(
+            "Label",
+            ObsidianNoteReference {
+                file: None,
+                label: Some("Label"),
+                section: Some("Heading"),
+            }
+            .display()
+        );
+    }
+}

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -1,6 +1,10 @@
-use obsidian_export::{ExportError, Exporter, FrontmatterStrategy};
+use obsidian_export::{
+    Context, ExportError, Exporter, FrontmatterStrategy, MarkdownEvents, PostprocessorResult,
+};
 use pretty_assertions::assert_eq;
-use std::fs::{create_dir, read_to_string, set_permissions, File, Permissions};
+use pulldown_cmark::{CowStr, Event};
+use serde_yaml::Value;
+use std::fs::{create_dir, read_to_string, remove_file, set_permissions, File, Permissions};
 use std::io::prelude::*;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -349,4 +353,109 @@ fn test_same_filename_different_directories() {
 
     let actual = read_to_string(tmp_dir.path().clone().join(PathBuf::from("Note.md"))).unwrap();
     assert_eq!(expected, actual);
+}
+
+/// This postprocessor replaces any instance of "foo" with "bar" in the note body.
+fn foo_to_bar(
+    ctx: Context,
+    events: MarkdownEvents,
+) -> (Context, MarkdownEvents, PostprocessorResult) {
+    let events = events
+        .into_iter()
+        .map(|event| match event {
+            Event::Text(text) => Event::Text(CowStr::from(text.replace("foo", "bar"))),
+            event => event,
+        })
+        .collect();
+    (ctx, events, PostprocessorResult::Continue)
+}
+
+/// This postprocessor appends "bar: baz" to frontmatter.
+fn append_frontmatter(
+    mut ctx: Context,
+    events: MarkdownEvents,
+) -> (Context, MarkdownEvents, PostprocessorResult) {
+    ctx.frontmatter.insert(
+        Value::String("bar".to_string()),
+        Value::String("baz".to_string()),
+    );
+    (ctx, events, PostprocessorResult::Continue)
+}
+
+// The purpose of this test to verify the `append_frontmatter` postprocessor is called to extend
+// the frontmatter, and the `foo_to_bar` postprocessor is called to replace instances of "foo" with
+// "bar" (only in the note body).
+#[test]
+fn test_postprocessors() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/postprocessors"),
+        tmp_dir.path().to_path_buf(),
+    );
+    exporter.add_postprocessor(&foo_to_bar);
+    exporter.add_postprocessor(&append_frontmatter);
+
+    exporter.run().unwrap();
+
+    let expected = read_to_string("tests/testdata/expected/postprocessors/Note.md").unwrap();
+    let actual = read_to_string(tmp_dir.path().clone().join(PathBuf::from("Note.md"))).unwrap();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_postprocessor_stophere() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/postprocessors"),
+        tmp_dir.path().to_path_buf(),
+    );
+
+    exporter.add_postprocessor(&|ctx, mdevents| (ctx, mdevents, PostprocessorResult::StopHere));
+    exporter.add_postprocessor(&|_, _| panic!("should not be called due to above processor"));
+    exporter.run().unwrap();
+}
+
+#[test]
+fn test_postprocessor_stop_and_skip() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+    let note_path = tmp_dir.path().clone().join(PathBuf::from("Note.md"));
+
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/postprocessors"),
+        tmp_dir.path().to_path_buf(),
+    );
+    exporter.run().unwrap();
+
+    assert!(note_path.exists());
+    remove_file(&note_path).unwrap();
+
+    exporter
+        .add_postprocessor(&|ctx, mdevents| (ctx, mdevents, PostprocessorResult::StopAndSkipNote));
+    exporter.run().unwrap();
+
+    assert!(!note_path.exists());
+}
+
+#[test]
+fn test_postprocessor_change_destination() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+    let original_note_path = tmp_dir.path().clone().join(PathBuf::from("Note.md"));
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/postprocessors"),
+        tmp_dir.path().to_path_buf(),
+    );
+    exporter.run().unwrap();
+
+    assert!(original_note_path.exists());
+    remove_file(&original_note_path).unwrap();
+
+    exporter.add_postprocessor(&|mut ctx, mdevents| {
+        ctx.destination.set_file_name("MovedNote.md");
+        (ctx, mdevents, PostprocessorResult::Continue)
+    });
+    exporter.run().unwrap();
+
+    let new_note_path = tmp_dir.path().clone().join(PathBuf::from("MovedNote.md"));
+    assert!(!original_note_path.exists());
+    assert!(new_note_path.exists());
 }

--- a/tests/testdata/expected/postprocessors/Note.md
+++ b/tests/testdata/expected/postprocessors/Note.md
@@ -1,0 +1,8 @@
+---
+foo: bar
+bar: baz
+---
+
+# Title
+
+Sentence containing bar.

--- a/tests/testdata/input/postprocessors/Note.md
+++ b/tests/testdata/input/postprocessors/Note.md
@@ -1,0 +1,7 @@
+---
+foo: bar
+---
+
+# Title
+
+Sentence containing foo.


### PR DESCRIPTION
This branch tracks the implementation of postprocessing support (functions to transform the generated markdown before it's written out to the destination file).