### PR TITLE
Recognize notes beginning with underscores

### DIFF
--- a/tests/testdata/expected/main-samples/obsidian-wikilinks.md
+++ b/tests/testdata/expected/main-samples/obsidian-wikilinks.md
@@ -8,6 +8,8 @@ Link to [pure markdown examples](pure-markdown-examples.md#heading-1).
 
 Link to [uppercased-note](Uppercased-note.md).
 
+Link to [\_underscored-note](_underscored-note.md).
+
 Link within backticks: `[[pure-markdown-examples]]`
 
 ````

--- a/tests/testdata/input/main-samples/_underscored-note.md
+++ b/tests/testdata/input/main-samples/_underscored-note.md
@@ -1,0 +1,3 @@
+Older versions of obsidian-export contained a bug where files beginning with an underscore wouldn't get resolved correctly.
+
+This file, and the link to it in `obsidian-wikilinks.md`, serves as a regression test for this issue.

--- a/tests/testdata/input/main-samples/obsidian-wikilinks.md
+++ b/tests/testdata/input/main-samples/obsidian-wikilinks.md
@@ -8,6 +8,8 @@ Link to [[pure-markdown-examples#Heading 1|pure markdown examples]].
 
 Link to [[uppercased-note]].
 
+Link to [[_underscored-note]].
+
 Link within backticks: `[[pure-markdown-examples]]`
 
 ```


### PR DESCRIPTION
Notes with an underscore would fail to be recognized within Obsidian `[[_WikiLinks]]` due to the assumption that the underlying Markdown parser (pulldown_cmark) would emit the text between `[[` and `]]` as a single event.

The note parser has now been rewritten to use a more reliable state machine which correctly recognizes this corner-case (and likely some others).