### PR TITLE
specify the note to export as a separate argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,17 @@ struct Opts {
     #[options(help = "Display version information")]
     version: bool,
 
-    #[options(help = "Source file containing reference", free, required)]
+    #[options(help = "Path to the vault root", free, required)]
     source: Option<PathBuf>,
 
     #[options(help = "Destination file being linked to", free, required)]
     destination: Option<PathBuf>,
+
+    #[options(
+        short = "t",
+        help = "Start scanning from this note"
+    )]
+    root_note: Option<PathBuf>,
 
     #[options(
         help = "Frontmatter strategy (one of: always, never, auto)",
@@ -75,6 +81,7 @@ fn main() {
     };
 
     let mut exporter = Exporter::new(source, destination);
+    exporter.set_root_note(args.root_note);
     exporter.frontmatter_strategy(args.frontmatter_strategy);
     exporter.process_embeds_recursively(!args.no_recursive_embeds);
     exporter.walk_options(walk_options);


### PR DESCRIPTION
Hi! I suggest the first step towards the exporting of the subgraph. The functionality I lack now, is actual triggering of the export when the reference is discovered in the note.

In this form it is also possible to call obsidian-exporter as a tool from the other code, that conducts the traversal.