### PR TITLE
Uniform rendering of links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,10 +665,15 @@ impl<'a> Exporter<'a> {
                     .unwrap_or_else(|| context.current_file().to_str().unwrap()),
                 context.current_file().display(),
             );
+            let dummy_link_tag = pulldown_cmark::Tag::Link(
+                pulldown_cmark::LinkType::Inline,
+                CowStr::from(""),
+                CowStr::from(""),
+            );
             return vec![
-                Event::Start(Tag::Emphasis),
+                Event::Start(dummy_link_tag.clone()),
                 Event::Text(CowStr::from(reference.display())),
-                Event::End(Tag::Emphasis),
+                Event::End(dummy_link_tag.clone()),
             ];
         }
         let target_file = target_file.unwrap();

--- a/tests/testdata/expected/single-file/note.md
+++ b/tests/testdata/expected/single-file/note.md
@@ -1,3 +1,3 @@
-Link to *other-note*.
+Link to [other-note]().
 
-Link to *another note*.
+Link to [another note]().


### PR DESCRIPTION
Render all links as Link in the export. Remove the special case where
dead links were rendered as Emphasis instead. This makes it much easier
to style links in the final output.