### PR TITLE
Add filetime dependency and preserve modified time of exported files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -119,6 +125,18 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
 
 [[package]]
 name = "futures"
@@ -358,6 +376,7 @@ name = "obsidian-export"
 version = "23.12.0"
 dependencies = [
  "eyre",
+ "filetime",
  "gumdrop",
  "ignore",
  "matter",
@@ -441,7 +460,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "getopts",
  "memchr",
  "unicase",
@@ -483,6 +502,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -565,7 +593,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde_yaml = "0.9.34"
 slug = "0.1.5"
 snafu = "0.8.3"
 unicode-normalization = "0.1.23"
+filetime = "0.2.23"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/deny.toml
+++ b/deny.toml
@@ -62,6 +62,12 @@ skip = [
     #    result. We can then choose to again skip that version, or decide more
     #    drastic action is needed.
     "syn:<=1.0.109",
+    # filetime depends on redox_syscall which depends on bitflags 1.x, whereas
+    # other dependencies in our tree depends on bitflags 2.x. This should solve
+    # itself when a new release is made for filetime, as redox_syscall is
+    # deprecated and already replaced by libredox anyway
+    # (https://github.com/alexcrichton/filetime/pull/103)
+    "bitflags:<=1.3.2",
 ]
 wildcards = "deny"
 allow-wildcard-paths = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,13 @@ struct Opts {
 
     #[options(
         no_short,
+        help = "Preserve the mtime of exported files",
+        default = "false"
+    )]
+    preserve_mtime: bool,
+
+    #[options(
+        no_short,
         help = "Convert soft line breaks to hard line breaks. This mimics Obsidian's 'Strict line breaks' setting",
         default = "false"
     )]
@@ -97,6 +104,7 @@ fn main() {
     let mut exporter = Exporter::new(root, destination);
     exporter.frontmatter_strategy(args.frontmatter_strategy);
     exporter.process_embeds_recursively(!args.no_recursive_embeds);
+    exporter.preserve_mtime(args.preserve_mtime);
     exporter.walk_options(walk_options);
 
     if args.hard_linebreaks {

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -361,6 +361,44 @@ fn test_no_recursive_embeds() {
 }
 
 #[test]
+fn test_preserve_mtime() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/main-samples/"),
+        tmp_dir.path().to_path_buf(),
+    );
+    exporter.preserve_mtime(true);
+    exporter.run().expect("exporter returned error");
+
+    let src = "tests/testdata/input/main-samples/obsidian-wikilinks.md";
+    let dest = tmp_dir.path().join(PathBuf::from("obsidian-wikilinks.md"));
+    let src_meta = std::fs::metadata(src).unwrap();
+    let dest_meta = std::fs::metadata(dest).unwrap();
+
+    assert_eq!(src_meta.modified().unwrap(), dest_meta.modified().unwrap());
+}
+
+#[test]
+fn test_no_preserve_mtime() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/main-samples/"),
+        tmp_dir.path().to_path_buf(),
+    );
+    exporter.preserve_mtime(false);
+    exporter.run().expect("exporter returned error");
+
+    let src = "tests/testdata/input/main-samples/obsidian-wikilinks.md";
+    let dest = tmp_dir.path().join(PathBuf::from("obsidian-wikilinks.md"));
+    let src_meta = std::fs::metadata(src).unwrap();
+    let dest_meta = std::fs::metadata(dest).unwrap();
+
+    assert_ne!(src_meta.modified().unwrap(), dest_meta.modified().unwrap());
+}
+
+#[test]
 fn test_non_ascii_filenames() {
     let tmp_dir = TempDir::new().expect("failed to make tempdir");
 


### PR DESCRIPTION
Adds an option `--preserve-mtime` which preserves the last modified time metadata on exported files with accompanying tests. For the purpose of making this cross-platform, it uses/adds the [filetime](https://crates.io/crates/filetime) crate