### PR TITLE
Adding remove_obsidian_comments postprocessor to remove obsidian format comments

### DIFF
--- a/tests/postprocessors_test.rs
+++ b/tests/postprocessors_test.rs
@@ -1,4 +1,6 @@
-use obsidian_export::postprocessors::{filter_by_tags, softbreaks_to_hardbreaks};
+use obsidian_export::postprocessors::{
+    filter_by_tags, remove_obsidian_comments, softbreaks_to_hardbreaks,
+};
 use obsidian_export::{Context, Exporter, MarkdownEvents, PostprocessorResult};
 use pretty_assertions::assert_eq;
 use pulldown_cmark::{CowStr, Event};
@@ -289,4 +291,21 @@ fn test_filter_by_tags() {
             filename
         );
     }
+}
+
+#[test]
+fn test_remove_obsidian_comments() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/remove-comments/"),
+        tmp_dir.path().to_path_buf(),
+    );
+    exporter.add_postprocessor(&remove_obsidian_comments);
+    exporter.run().unwrap();
+
+    let expected =
+        read_to_string("tests/testdata/expected/remove-comments/test_comments.md").unwrap();
+    let actual = read_to_string(tmp_dir.path().join(PathBuf::from("test_comments.md"))).unwrap();
+
+    assert_eq!(expected, actual);
 }

--- a/tests/testdata/expected/remove-comments/test_comments.md
+++ b/tests/testdata/expected/remove-comments/test_comments.md
@@ -1,0 +1,6 @@
+Not a comment
+
+
+````md
+%% Comment in code block should be kept %%
+````

--- a/tests/testdata/input/remove-comments/test_comments.md
+++ b/tests/testdata/input/remove-comments/test_comments.md
@@ -1,0 +1,11 @@
+Not a comment
+%% Comment should be removed %%
+```md
+%% Comment in code block should be kept %%
+```
+
+%%
+This is
+a block comment
+that should be removed
+%%


### PR DESCRIPTION
Adding feature requested in issue #158 to remove Obsidian comments. As mentioned in PR #159 by @zoni I don't think it would be difficult to expand this postprocessor to instead of removing the comments making them HTML comments. 