### PR TITLE
Support markdown text formatting in reference labels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,6 +552,20 @@ impl<'a> Exporter<'a> {
                         ref_parser.ref_text.push_str(&text);
                         ref_parser.transition(RefParserState::ExpectRefTextOrCloseBracket);
                     }
+                    Event::Start(Tag::Emphasis) | Event::End(TagEnd::Emphasis) => {
+                        ref_parser.ref_text.push('*');
+                        ref_parser.transition(RefParserState::ExpectRefTextOrCloseBracket);
+
+                    }
+                    Event::Start(Tag::Strong) | Event::End(TagEnd::Strong)=> {
+                        ref_parser.ref_text.push_str("**");
+                        ref_parser.transition(RefParserState::ExpectRefTextOrCloseBracket);
+
+                    }
+                    Event::Start(Tag::Strikethrough) | Event::End(TagEnd::Strikethrough)=> {
+                        ref_parser.ref_text.push_str("~~");
+                        ref_parser.transition(RefParserState::ExpectRefTextOrCloseBracket);
+                    }
                     _ => {
                         ref_parser.transition(RefParserState::Resetting);
                     }
@@ -562,6 +576,16 @@ impl<'a> Exporter<'a> {
                     }
                     Event::Text(text) => {
                         ref_parser.ref_text.push_str(&text);
+                    }
+                    Event::Start(Tag::Emphasis) | Event::End(TagEnd::Emphasis) => {
+                        ref_parser.ref_text.push('*');
+
+                    }
+                    Event::Start(Tag::Strong) | Event::End(TagEnd::Strong)=> {
+                        ref_parser.ref_text.push_str("**");
+                    }
+                    Event::Start(Tag::Strikethrough) | Event::End(TagEnd::Strikethrough)=> {
+                        ref_parser.ref_text.push_str("~~");
                     }
                     _ => {
                         ref_parser.transition(RefParserState::Resetting);


### PR DESCRIPTION
The library currently fails to parse an Obsidian reference if it contains formatted text in the label

`[[example-link-target|Example **bold**, *italic*, or ~~strikethrough~~ text]]`

I wanted to fix this for my fork and it seems like an easy patch to upstream as well.

Happy to write some tests if you think it's warranted.