### PR TITLE
Enable Github-Flavored-Markdown extension

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,7 +486,8 @@ impl<'a> Exporter<'a> {
             | Options::ENABLE_STRIKETHROUGH
             | Options::ENABLE_TASKLISTS
             | Options::ENABLE_MATH
-            | Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
+            | Options::ENABLE_YAML_STYLE_METADATA_BLOCKS
+            | Options::ENABLE_GFM;
 
         let mut ref_parser = RefParser::new();
         let mut events = vec![];

--- a/tests/testdata/expected/main-samples/alert.md
+++ b/tests/testdata/expected/main-samples/alert.md
@@ -1,0 +1,15 @@
+
+ > [!NOTE]
+ > Note blockquote
+
+ > [!TIP]
+ > Tip blockquote
+
+ > [!IMPORTANT]
+ > Important blockquote
+
+ > [!WARNING]
+ > Warning blockquote
+
+ > [!CAUTION]
+ > Caution blockquote

--- a/tests/testdata/input/main-samples/alert.md
+++ b/tests/testdata/input/main-samples/alert.md
@@ -1,0 +1,14 @@
+> [!NOTE]
+> Note blockquote
+
+> [!TIP]
+> Tip blockquote
+
+> [!IMPORTANT]
+> Important blockquote
+
+> [!WARNING]
+> Warning blockquote
+
+> [!CAUTION]
+> Caution blockquote


### PR DESCRIPTION
Closes #328 

I discovered that there is support for markdown alerts in `pulldown-cmark` behind the `ENABLE_GFM` flag.