### PR TITLE
Parse obsidian-style comments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 
 use eyre::{eyre, Result};
 use gumdrop::Options;
-use obsidian_export::postprocessors::{filter_by_tags, softbreaks_to_hardbreaks};
+use obsidian_export::postprocessors::{
+    filter_by_tags, parse_obsidian_comments, softbreaks_to_hardbreaks,
+};
 use obsidian_export::{ExportError, Exporter, FrontmatterStrategy, WalkOptions};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -106,6 +108,8 @@ fn main() {
     exporter.process_embeds_recursively(!args.no_recursive_embeds);
     exporter.preserve_mtime(args.preserve_mtime);
     exporter.walk_options(walk_options);
+
+    exporter.add_postprocessor(&parse_obsidian_comments);
 
     if args.hard_linebreaks {
         exporter.add_postprocessor(&softbreaks_to_hardbreaks);

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -6,6 +6,7 @@ use std::io::prelude::*;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
+use obsidian_export::postprocessors::parse_obsidian_comments;
 use obsidian_export::{ExportError, Exporter, FrontmatterStrategy};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
@@ -458,4 +459,21 @@ fn test_same_filename_different_directories() {
 
     let actual = read_to_string(tmp_dir.path().join(PathBuf::from("Note.md"))).unwrap();
     assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_parse_obsidian_comments() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/comments/"),
+        tmp_dir.path().to_path_buf(),
+    );
+    exporter.add_postprocessor(&parse_obsidian_comments);
+    exporter.run().expect("exporter returned error");
+
+    assert_eq!(
+        read_to_string("tests/testdata/expected/comments/note.md").unwrap(),
+        read_to_string(tmp_dir.path().join(PathBuf::from("note.md"))).unwrap(),
+    );
 }

--- a/tests/testdata/expected/comments/note.md
+++ b/tests/testdata/expected/comments/note.md
@@ -1,0 +1,8 @@
+Test
+
+<!-- A comment -->
+
+Test2
+<!-- A comment containing embedded markup -->
+
+This sentence is <!-- not --> true.

--- a/tests/testdata/input/comments/note.md
+++ b/tests/testdata/input/comments/note.md
@@ -1,0 +1,8 @@
+Test
+
+%% A comment %%
+
+Test2
+%% A comment containing [[embedded]] **markup** %%
+
+This sentence is %% not %% true.


### PR DESCRIPTION
These comments are not part of the document proper and it's tricky when they contain other markup.

A future improvement could be to translate these into HTML comments in the output.